### PR TITLE
Add BirthdayDateRangeFilter in birthdayfilters

### DIFF
--- a/queryfilter/birthdayfilters.py
+++ b/queryfilter/birthdayfilters.py
@@ -15,8 +15,7 @@ class BirthdayAgeRangeFilter(FieldFilter):
             range_end_int = int(range_end)
 
         def by_value_of_dict_field_in_range(dictobj):
-            birth_year = dictobj.get(self.field_name)
-            age = self.count_age(birth_year)
+            age = int(dictobj.get(self.field_name))
             return (
                 (range_start is None or age >= range_start_int)
                 and

--- a/queryfilter/birthdayfilters.py
+++ b/queryfilter/birthdayfilters.py
@@ -30,7 +30,7 @@ class BirthdayDateRangeFilter(FieldFilter):
                 return True
             if (month < month_end):
                 return True
-            if (month == month_end) and day <= day_start:
+            if (month == month_end) and day <= day_end:
                 return True
             return False
 

--- a/queryfilter/birthdayfilters.py
+++ b/queryfilter/birthdayfilters.py
@@ -64,16 +64,10 @@ class BirthdayDateRangeFilter(FieldFilter):
             return True
 
         def smaller_or_equal_to_range_end(month, day):
-            import alog
-            alog.info((month, day))
-            alog.info((month_end, day_end))
             if month < month_end:
-                alog.info("V")
                 return True
             if month == month_end and day <= day_end:
-                alog.info("V")
                 return True
-            alog.info("V")
             return False
 
         def filter_both_start_and_end(month, day):

--- a/queryfilter/birthdayfilters.py
+++ b/queryfilter/birthdayfilters.py
@@ -1,0 +1,101 @@
+from __future__ import absolute_import
+
+from .base import FieldFilter
+from .queryfilter import QueryFilter
+
+
+@QueryFilter.register_type_condition('birthday', 'age_range')
+class BirthdayAgeRangeFilter(FieldFilter):
+    def on_dicts(self, dicts):
+        range_start = self.filter_args.get("start")
+        if range_start is not None:
+            range_start_int = int(range_start)
+        range_end = self.filter_args.get("end")
+        if range_end is not None:
+            range_end_int = int(range_end)
+
+        def by_value_of_dict_field_in_range(dictobj):
+            birth_year = dictobj.get(self.field_name)
+            age = self.count_age(birth_year)
+            return (
+                (range_start is None or age >= range_start_int)
+                and
+                (range_end is None or age <= range_end_int)
+            )
+
+        return list(filter(by_value_of_dict_field_in_range, dicts))
+
+
+@QueryFilter.register_type_condition('birthday', 'date_range')
+class BirthdayDateRangeFilter(FieldFilter):
+    def split_month_day(self, birth):
+        month, day = birth.split("/")
+        return int(month), int(day)
+
+    def on_dicts(self, dicts):
+        range_start = self.filter_args.get("start")
+        range_end = self.filter_args.get("end")
+        to_filter_with_range_start = range_start is not None
+        to_filter_with_range_end = range_end is not None
+        if not to_filter_with_range_start and not to_filter_with_range_end:
+            return dicts
+
+        if to_filter_with_range_start:
+            month_start, day_start = self.split_month_day(range_start)
+        if to_filter_with_range_end:
+            month_end, day_end = self.split_month_day(range_end)
+
+        def in_date_range_across_year_end(month, day):
+            if (month > month_start):
+                return True
+            if (month == month_start) and day >= day_start:
+                return True
+            if (month < month_end):
+                return True
+            if (month == month_end) and day <= day_start:
+                return True
+            return False
+
+        def larger_or_equal_to_range_start(month, day):
+            if month < month_start:
+                return False
+            if month == month_start and day < day_start:
+                return False
+            return True
+
+        def smaller_or_equal_to_range_end(month, day):
+            import alog
+            alog.info((month, day))
+            alog.info((month_end, day_end))
+            if month < month_end:
+                alog.info("V")
+                return True
+            if month == month_end and day <= day_end:
+                alog.info("V")
+                return True
+            alog.info("V")
+            return False
+
+        def filter_both_start_and_end(month, day):
+            range_across_year_end = month_end < month_start
+            if range_across_year_end:
+                return in_date_range_across_year_end(month, day)
+            return (larger_or_equal_to_range_start(month, day)
+                    and smaller_or_equal_to_range_end(month, day))
+
+        def in_given_range(month, day):
+            if to_filter_with_range_start and to_filter_with_range_end:
+                return filter_both_start_and_end(month, day)
+
+            if to_filter_with_range_start:
+                return larger_or_equal_to_range_start(month, day)
+
+            if to_filter_with_range_end:
+                return smaller_or_equal_to_range_end(month, day)
+
+        def by_value_of_dict_field_in_range(dictobj):
+            value = dictobj.get(self.field_name)
+            month, day = self.split_month_day(value)
+            return in_given_range(month, day)
+
+        return list(filter(by_value_of_dict_field_in_range, dicts))

--- a/queryfilter/birthdayfilters.py
+++ b/queryfilter/birthdayfilters.py
@@ -4,27 +4,6 @@ from .base import FieldFilter
 from .queryfilter import QueryFilter
 
 
-@QueryFilter.register_type_condition('birthday', 'age_range')
-class BirthdayAgeRangeFilter(FieldFilter):
-    def on_dicts(self, dicts):
-        range_start = self.filter_args.get("start")
-        if range_start is not None:
-            range_start_int = int(range_start)
-        range_end = self.filter_args.get("end")
-        if range_end is not None:
-            range_end_int = int(range_end)
-
-        def by_value_of_dict_field_in_range(dictobj):
-            age = int(dictobj.get(self.field_name))
-            return (
-                (range_start is None or age >= range_start_int)
-                and
-                (range_end is None or age <= range_end_int)
-            )
-
-        return list(filter(by_value_of_dict_field_in_range, dicts))
-
-
 @QueryFilter.register_type_condition('birthday', 'date_range')
 class BirthdayDateRangeFilter(FieldFilter):
     def split_month_day(self, birth):

--- a/queryfilter/tests/test_birthdayfilters.py
+++ b/queryfilter/tests/test_birthdayfilters.py
@@ -18,7 +18,7 @@ class TestBirthdayDateRangeFilter(object):
 
     def setup(self):
         self.field_name_to_test = "birth"
-        self.dates_to_test = ("12/31", "01/11", "02/29")
+        self.dates_to_test = ("12/31", "01/11", "02/29", "01/11")
         self.dataset_to_test = [
             {self.field_name_to_test: date} for date in self.dates_to_test
         ]
@@ -47,10 +47,10 @@ class TestBirthdayDateRangeFilter(object):
             "end": "01/30",
         })
         results_after_filter = date_filter.on_dicts(self.dataset_to_test)
-        assert len(results_after_filter) == 2
+        assert len(results_after_filter) == 3
         values_of_result_filters = self.values_of_filters(results_after_filter)
-        assert self.dates_to_test[0] in values_of_result_filters
-        assert self.dates_to_test[1] in values_of_result_filters
+        assert "12/31" in values_of_result_filters
+        assert "01/11" in values_of_result_filters
 
     def test_date_range_not_across_year_should_match(self):
         date_filter = BirthdayDateRangeFilter(self.field_name_to_test, {

--- a/queryfilter/tests/test_birthdayfilters.py
+++ b/queryfilter/tests/test_birthdayfilters.py
@@ -1,9 +1,6 @@
 from __future__ import absolute_import
 
-from ..birthdayfilters import (
-    BirthdayDateRangeFilter,
-    BirthdayAgeRangeFilter
-)
+from ..birthdayfilters import BirthdayDateRangeFilter
 
 
 class TestBirthdayDateRangeFilter(object):
@@ -60,51 +57,3 @@ class TestBirthdayDateRangeFilter(object):
         results_after_filter = date_filter.on_dicts(self.dataset_to_test)
         assert len(results_after_filter) == 1
         assert results_after_filter[0]["birth"] == "02/29"
-
-
-class TestBirthdayAgeRangeFilter(object):
-
-    def setup(self):
-        self.field_name_to_test = "age"
-        self.ages_to_test = ("14", "21", "99", "21")
-        self.dataset_to_test = [
-            {self.field_name_to_test: age} for age in self.ages_to_test
-        ]
-
-    def test_filter_with_exact_age_should_match_on_expected_amount(self):
-        age_filter = BirthdayAgeRangeFilter(self.field_name_to_test, {
-            "start": self.ages_to_test[0],
-            "end": self.ages_to_test[0]
-        })
-        results_after_filter = age_filter.on_dicts(self.dataset_to_test)
-        assert len(results_after_filter) == 1
-
-    def test_filter_with_date_not_matched_should_get_empty_results(self):
-        age_not_matched = "18"
-        assert age_not_matched not in self.ages_to_test
-        age_filter = BirthdayAgeRangeFilter(self.field_name_to_test, {
-            "start": age_not_matched,
-            "end": age_not_matched
-        })
-        results_after_filter = age_filter.on_dicts(self.dataset_to_test)
-        assert len(results_after_filter) == 0
-
-    def test_filter_with_date_range_all_covered_should_match_all(self):
-        smallest_age_of_test_dataset = int(min(self.ages_to_test))
-        largest_age_of_test_dataset = int(max(self.ages_to_test))
-        date_filter = BirthdayAgeRangeFilter(self.field_name_to_test, {
-            "start": str(smallest_age_of_test_dataset - 1),
-            "end": str(largest_age_of_test_dataset + 1),
-        })
-        results_after_filter = date_filter.on_dicts(self.dataset_to_test)
-        assert len(results_after_filter) == len(self.dataset_to_test)
-
-    def test_date_range_across_year_should_match(self):
-        smallest_age_of_test_dataset = int(min(self.ages_to_test))
-        largest_age_of_test_dataset = int(max(self.ages_to_test))
-        date_filter = BirthdayAgeRangeFilter(self.field_name_to_test, {
-            "start": str(smallest_age_of_test_dataset + 1),
-            "end": str(largest_age_of_test_dataset - 1),
-        })
-        results_after_filter = date_filter.on_dicts(self.dataset_to_test)
-        assert len(results_after_filter) == (len(self.dataset_to_test) - 2)

--- a/queryfilter/tests/test_birthdayfilters.py
+++ b/queryfilter/tests/test_birthdayfilters.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 
 from ..birthdayfilters import (
-    BirthdayDateRangeFilter
+    BirthdayDateRangeFilter,
+    BirthdayAgeRangeFilter
 )
 
 
@@ -59,3 +60,51 @@ class TestBirthdayDateRangeFilter(object):
         results_after_filter = date_filter.on_dicts(self.dataset_to_test)
         assert len(results_after_filter) == 1
         assert results_after_filter[0]["birth"] == "02/29"
+
+
+class TestBirthdayAgeRangeFilter(object):
+
+    def setup(self):
+        self.field_name_to_test = "age"
+        self.ages_to_test = ("14", "21", "99", "21")
+        self.dataset_to_test = [
+            {self.field_name_to_test: age} for age in self.ages_to_test
+        ]
+
+    def test_filter_with_exact_age_should_match_on_expected_amount(self):
+        age_filter = BirthdayAgeRangeFilter(self.field_name_to_test, {
+            "start": self.ages_to_test[0],
+            "end": self.ages_to_test[0]
+        })
+        results_after_filter = age_filter.on_dicts(self.dataset_to_test)
+        assert len(results_after_filter) == 1
+
+    def test_filter_with_date_not_matched_should_get_empty_results(self):
+        age_not_matched = "18"
+        assert age_not_matched not in self.ages_to_test
+        age_filter = BirthdayAgeRangeFilter(self.field_name_to_test, {
+            "start": age_not_matched,
+            "end": age_not_matched
+        })
+        results_after_filter = age_filter.on_dicts(self.dataset_to_test)
+        assert len(results_after_filter) == 0
+
+    def test_filter_with_date_range_all_covered_should_match_all(self):
+        smallest_age_of_test_dataset = int(min(self.ages_to_test))
+        largest_age_of_test_dataset = int(max(self.ages_to_test))
+        date_filter = BirthdayAgeRangeFilter(self.field_name_to_test, {
+            "start": str(smallest_age_of_test_dataset - 1),
+            "end": str(largest_age_of_test_dataset + 1),
+        })
+        results_after_filter = date_filter.on_dicts(self.dataset_to_test)
+        assert len(results_after_filter) == len(self.dataset_to_test)
+
+    def test_date_range_across_year_should_match(self):
+        smallest_age_of_test_dataset = int(min(self.ages_to_test))
+        largest_age_of_test_dataset = int(max(self.ages_to_test))
+        date_filter = BirthdayAgeRangeFilter(self.field_name_to_test, {
+            "start": str(smallest_age_of_test_dataset + 1),
+            "end": str(largest_age_of_test_dataset - 1),
+        })
+        results_after_filter = date_filter.on_dicts(self.dataset_to_test)
+        assert len(results_after_filter) == (len(self.dataset_to_test) - 2)

--- a/queryfilter/tests/test_birthdayfilters.py
+++ b/queryfilter/tests/test_birthdayfilters.py
@@ -1,0 +1,61 @@
+from __future__ import absolute_import
+
+from ..birthdayfilters import (
+    BirthdayDateRangeFilter
+)
+
+
+class TestBirthdayDateRangeFilter(object):
+
+    def date_to_test(self, month_to_test=None, day_to_test=None):
+        month_to_test = month_to_test or self.month_to_test
+        day_to_test = day_to_test or self.day_to_test
+        return month_to_test + "/" + day_to_test
+
+    def values_of_filters(self, results):
+        return [result[self.field_name_to_test] for result in results]
+
+    def setup(self):
+        self.field_name_to_test = "birth"
+        self.dates_to_test = ("12/31", "01/11", "02/29")
+        self.dataset_to_test = [
+            {self.field_name_to_test: date} for date in self.dates_to_test
+        ]
+
+    def test_date_matched_with_same_date_should_be_in_range(self):
+        date_filter = BirthdayDateRangeFilter(self.field_name_to_test, {
+            "start": self.dates_to_test[0],
+            "end": self.dates_to_test[0]
+        })
+        results_after_filter = date_filter.on_dicts(self.dataset_to_test)
+        assert len(results_after_filter) == 1
+
+    def test_date_not_matched_with_same_date_should_not_be_in_range(self):
+        date_not_matched = "12/30"
+        assert date_not_matched not in self.dates_to_test
+        date_filter = BirthdayDateRangeFilter(self.field_name_to_test, {
+            "start": date_not_matched,
+            "end": date_not_matched
+        })
+        results_after_filter = date_filter.on_dicts(self.dataset_to_test)
+        assert len(results_after_filter) == 0
+
+    def test_date_range_across_year_should_match(self):
+        date_filter = BirthdayDateRangeFilter(self.field_name_to_test, {
+            "start": "12/30",
+            "end": "01/30",
+        })
+        results_after_filter = date_filter.on_dicts(self.dataset_to_test)
+        assert len(results_after_filter) == 2
+        values_of_result_filters = self.values_of_filters(results_after_filter)
+        assert self.dates_to_test[0] in values_of_result_filters
+        assert self.dates_to_test[1] in values_of_result_filters
+
+    def test_date_range_not_across_year_should_match(self):
+        date_filter = BirthdayDateRangeFilter(self.field_name_to_test, {
+            "start": "01/30",
+            "end": "12/30",
+        })
+        results_after_filter = date_filter.on_dicts(self.dataset_to_test)
+        assert len(results_after_filter) == 1
+        assert results_after_filter[0]["birth"] == "02/29"

--- a/queryfilter/tests/test_birthdayfilters.py
+++ b/queryfilter/tests/test_birthdayfilters.py
@@ -40,7 +40,7 @@ class TestBirthdayDateRangeFilter(object):
 
     def test_date_range_across_year_should_match(self):
         date_filter = BirthdayDateRangeFilter(self.field_name_to_test, {
-            "start": "12/30",
+            "start": "12/10",
             "end": "01/30",
         })
         results_after_filter = date_filter.on_dicts(self.dataset_to_test)


### PR DESCRIPTION
# Purpose

Support **birthday** filters.

Usage:
```python
from queryfilter.birthdayfilters import BirthdayDateRangeFilter

birthday_fieldname = "birth"
date_filter = BirthdayDateRangeFilter(birthday_fieldname, {
    "start": "01/13",
    "end": "03/01"
})
results_after_filter = date_filter.on_dicts(dataset_to_test)
```

# Changes

- Added `queryfilter/birthdayfilters.py` with `TestBirthdayDateRangeFilter`.

# Risk

None.
