### PR TITLE
Set default behaviors for None value with options

### DIFF
--- a/queryfilter/__init__.py
+++ b/queryfilter/__init__.py
@@ -1,7 +1,3 @@
-# # flake8: noqa: imported as root level objects
 from __future__ import absolute_import
 
-from . import textfilters
-from . import numberfilters
-from . import birthdayfilters
-from .queryfilter import QueryFilter  # Need to be last imported.
+from .queryfilter import QueryFilter  # noqa: imported as root level object

--- a/queryfilter/__init__.py
+++ b/queryfilter/__init__.py
@@ -1,3 +1,7 @@
+# # flake8: noqa: imported as root level objects
 from __future__ import absolute_import
 
-from .queryfilter import QueryFilter  # noqa: imported as root level object
+from . import textfilters
+from . import numberfilters
+from . import birthdayfilters
+from .queryfilter import QueryFilter  # Need to be last imported.

--- a/queryfilter/base.py
+++ b/queryfilter/base.py
@@ -17,10 +17,11 @@ class FieldFilter(object):
     ):
         self.field_name = field_name
         self.filter_args = filter_args
-        default_filter_options = {
+        self.options = {
             "drop_none": True
         }
-        self.options = options or default_filter_options
+        passed_in_options = options if options else {}
+        self.options.update(passed_in_options)
 
     # TODO: Put it back when we need it
     # @abc.abstractmethod

--- a/queryfilter/base.py
+++ b/queryfilter/base.py
@@ -45,9 +45,9 @@ class FieldFilter(object):
 class BaseDictFilter(object):
     def __init__(self, *args, **kwargs):
         super(BaseDictFilter, self).__init__(*args, **kwargs)
-        options_kwarg = kwargs["options"]
-        none_for_missing_field = options_kwarg.get("none_for_missing_field", True)
-        self.options["none_for_missing_field"] = none_for_missing_field
+        options_kwargs = kwargs["options"]
+        option_kw_value = options_kwargs.get("none_for_missing_field", True)
+        self.options["none_for_missing_field"] = option_kw_value
 
     def get(self, dictobj, field_name):
         if (field_name not in dictobj) and (

--- a/queryfilter/base.py
+++ b/queryfilter/base.py
@@ -45,9 +45,12 @@ class FieldFilter(object):
 class BaseDictFilter(object):
     def __init__(self, *args, **kwargs):
         super(BaseDictFilter, self).__init__(*args, **kwargs)
-        self.none_as_missing_key = kwargs.get("none_as_missing_key", True)
+        options_kwarg = kwargs["options"]
+        none_for_missing_field = options_kwarg.get("none_for_missing_field", True)
+        self.options["none_for_missing_field"] = none_for_missing_field
 
     def get(self, dictobj, field_name):
-        if (field_name not in dictobj) and (not self.none_as_missing_key):
+        if (field_name not in dictobj) and (
+                not self.options["none_for_missing_field"]):
             raise FieldNotFound(field_name)
         return dictobj.get(field_name)

--- a/queryfilter/base.py
+++ b/queryfilter/base.py
@@ -1,7 +1,7 @@
 import abc
 
 from .exceptions import (
-    FilterOnNoneValueError,
+    FilterOnNoneValue,
     FieldNotFound
 )
 
@@ -39,13 +39,13 @@ class FieldFilter(object):
     def false_with_drop_none_else_raise(self, field_name):
         if self.options["drop_none"]:
             return False
-        raise FilterOnNoneValueError(field_name)
+        raise FilterOnNoneValue(field_name)
 
 
-class BaseDictFilter(object):
+class DictFilterMixin(object):
     def __init__(self, *args, **kwargs):
-        super(BaseDictFilter, self).__init__(*args, **kwargs)
-        options_kwargs = kwargs["options"]
+        super(DictFilterMixin, self).__init__(*args, **kwargs)
+        options_kwargs = kwargs.get("options", {})
         option_kw_value = options_kwargs.get("none_for_missing_field", True)
         self.options["none_for_missing_field"] = option_kw_value
 

--- a/queryfilter/birthdayfilters.py
+++ b/queryfilter/birthdayfilters.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import
 
-from .base import FieldFilter, BaseDictFilter
+from .base import FieldFilter, DictFilterMixin
 from .queryfilter import QueryFilter
 
 
 @QueryFilter.register_type_condition('birthday', 'date_range')
-class BirthdayDateRangeFilter(BaseDictFilter, FieldFilter):
+class BirthdayDateRangeFilter(DictFilterMixin, FieldFilter):
     def split_month_day(self, birth):
         month, day = birth.split("/")
         return int(month), int(day)

--- a/queryfilter/birthdayfilters.py
+++ b/queryfilter/birthdayfilters.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import
 
-from .base import FieldFilter
+from .base import FieldFilter, BaseDictFilter
 from .queryfilter import QueryFilter
 
 
 @QueryFilter.register_type_condition('birthday', 'date_range')
-class BirthdayDateRangeFilter(FieldFilter):
+class BirthdayDateRangeFilter(BaseDictFilter, FieldFilter):
     def split_month_day(self, birth):
         month, day = birth.split("/")
         return int(month), int(day)
@@ -66,7 +66,9 @@ class BirthdayDateRangeFilter(FieldFilter):
                 return smaller_or_equal_to_range_end(month, day)
 
         def by_value_of_dict_field_in_range(dictobj):
-            value = dictobj.get(self.field_name)
+            value = self.get(dictobj, self.field_name)
+            if value is None:
+                return self.false_with_drop_none_else_raise(self.field_name)
             month, day = self.split_month_day(value)
             return in_given_range(month, day)
 

--- a/queryfilter/exceptions.py
+++ b/queryfilter/exceptions.py
@@ -4,9 +4,9 @@ class QueryFilterException(Exception):
     pass
 
 
-class FieldNotFound(Exception):
+class FieldNotFound(QueryFilterException):
     pass
 
 
-class FilterOnNoneValueError(Exception):
+class FilterOnNoneValue(QueryFilterException):
     pass

--- a/queryfilter/exceptions.py
+++ b/queryfilter/exceptions.py
@@ -1,0 +1,12 @@
+
+
+class QueryFilterException(Exception):
+    pass
+
+
+class FieldNotFound(Exception):
+    pass
+
+
+class FilterOnNoneValueError(Exception):
+    pass

--- a/queryfilter/numberfilters.py
+++ b/queryfilter/numberfilters.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import
 
-from .base import FieldFilter, BaseDictFilter
+from .base import FieldFilter, DictFilterMixin
 from .queryfilter import QueryFilter
 
 
 @QueryFilter.register_type_condition('number')
-class NumberRangeFilter(BaseDictFilter, FieldFilter):
+class NumberRangeFilter(DictFilterMixin, FieldFilter):
     def get_query_range(self):
         min_value = self.filter_args.get("min")
         max_value = self.filter_args.get("max")

--- a/queryfilter/tests/test_exceptions.py
+++ b/queryfilter/tests/test_exceptions.py
@@ -1,0 +1,18 @@
+
+
+from .. import exceptions as queryfilter_exceptions
+
+
+def test_all_exceptions_should_inherit_QueryFilterException():
+    exception_class_names = []
+    for name in dir(queryfilter_exceptions):
+        if (
+                (not name.startswith("_"))
+                and name != "QueryFilterException"
+        ):
+            exception_class_names.append(name)
+
+    exception_classes = [getattr(queryfilter_exceptions, name)
+                         for name in exception_class_names]
+    for exc in exception_classes:
+        assert queryfilter_exceptions.QueryFilterException in exc.__mro__

--- a/queryfilter/tests/test_numberfilters.py
+++ b/queryfilter/tests/test_numberfilters.py
@@ -1,76 +1,95 @@
 from __future__ import absolute_import
 
+import pytest
+
 from ..numberfilters import NumberRangeFilter
 
 
 class TestNumberRangeFilter(object):
     def setup(self):
         self.field_name_to_test = "age"
-        self.number_to_test = 5
+        self.numbers_to_test = (0, 3, None, 2, 2, 4)
         self.dicts = [
-            {self.field_name_to_test: self.number_to_test}
+            {self.field_name_to_test: num}
+            for num in self.numbers_to_test
         ]
 
-    def test_number_in_range(self):
-        text_filter = NumberRangeFilter(self.field_name_to_test, {
-            "max": self.number_to_test+1, "min": self.number_to_test-1
-        })
-        assert len(text_filter.on_dicts(self.dicts)) == 1
+    @property
+    def max_test_number(self):
+        no_none_values = (
+            d[self.field_name_to_test] for d in self.no_none_test_numbers
+        )
+        return max(no_none_values)
 
-    def test_number_out_of_range_too_small(self):
+    @property
+    def min_test_number(self):
+        no_none_values = (
+            d[self.field_name_to_test] for d in self.no_none_test_numbers
+        )
+        return min(no_none_values)
+
+    @property
+    def no_none_test_numbers(self):
+        return filter(
+            lambda d: d[self.field_name_to_test] is not None, self.dicts
+        )
+
+    def test_filter_range_cover_all_tesT_numbers_should_get_same_numbers(self):
         text_filter = NumberRangeFilter(self.field_name_to_test, {
-            "max": self.number_to_test+1, "min": self.number_to_test+1
+            "max": self.max_test_number + 1, "min": self.min_test_number - 1
+        })
+        filtered_dicts = text_filter.on_dicts(self.dicts)
+        assert len(filtered_dicts) == len(list(self.no_none_test_numbers))
+
+    def test_range_smaller_than_test_numbers_should_get_empty_list(self):
+        text_filter = NumberRangeFilter(self.field_name_to_test, {
+            "max": self.min_test_number - 1, "min": self.min_test_number - 1
         })
         assert len(text_filter.on_dicts(self.dicts)) == 0
 
-    def test_number_out_of_range_too_big(self):
+    def test_range_larger_than_test_numbers_should_get_empty_list(self):
         text_filter = NumberRangeFilter(self.field_name_to_test, {
-            "max": self.number_to_test-1, "min": self.number_to_test-1
+            "max": self.max_test_number + 1, "min": self.max_test_number + 1
         })
         assert len(text_filter.on_dicts(self.dicts)) == 0
 
-    def test_number_right_on_range(self):
+    def test_range_with_0_should_get_result(self):
         text_filter = NumberRangeFilter(self.field_name_to_test, {
-            "max": self.number_to_test, "min": self.number_to_test
+            "max": 0, "min": 0
         })
         assert len(text_filter.on_dicts(self.dicts)) == 1
 
     def test_number_has_no_range(self):
         text_filter = NumberRangeFilter(self.field_name_to_test, {})
-        assert len(text_filter.on_dicts(self.dicts)) == 1
+        filtered_dicts = text_filter.on_dicts(self.dicts)
+        assert len(filtered_dicts) == len(list(self.no_none_test_numbers))
 
-    def test_number_under_max(self):
+    def test_range_with_smaller_max_option_only(self):
         text_filter = NumberRangeFilter(self.field_name_to_test, {
-            "max": self.number_to_test+1
+            "max": self.max_test_number - 1
         })
-        assert len(text_filter.on_dicts(self.dicts)) == 1
+        filtered_dicts = text_filter.on_dicts(self.dicts)
+        assert len(filtered_dicts) == len(list(self.no_none_test_numbers)) - 1
 
-    def test_number_over_max(self):
+    @pytest.mark.parametrize("max_bias", [1, 0])
+    def test_range_with_larger_or_equal_max_option_only(self, max_bias):
         text_filter = NumberRangeFilter(self.field_name_to_test, {
-            "max": self.number_to_test-1
+            "max": self.max_test_number + max_bias
         })
-        assert len(text_filter.on_dicts(self.dicts)) == 0
+        filtered_dicts = text_filter.on_dicts(self.dicts)
+        assert len(filtered_dicts) == len(list(self.no_none_test_numbers))
 
-    def test_number_at_max(self):
+    def test_range_with_larger_min_option_only(self):
         text_filter = NumberRangeFilter(self.field_name_to_test, {
-            "max": self.number_to_test
+            "min": self.min_test_number + 1
         })
-        assert len(text_filter.on_dicts(self.dicts)) == 1
+        filtered_dicts = text_filter.on_dicts(self.dicts)
+        assert len(filtered_dicts) == len(list(self.no_none_test_numbers)) - 1
 
-    def test_number_under_min(self):
+    @pytest.mark.parametrize("min_bias", [1, 0])
+    def test_range_with_smaller_or_equal_min_option_only(self, min_bias):
         text_filter = NumberRangeFilter(self.field_name_to_test, {
-            "min": self.number_to_test+1
+            "min": self.min_test_number - min_bias
         })
-        assert len(text_filter.on_dicts(self.dicts)) == 0
-
-    def test_number_over_min(self):
-        text_filter = NumberRangeFilter(self.field_name_to_test, {
-            "min": self.number_to_test-1
-        })
-        assert len(text_filter.on_dicts(self.dicts)) == 1
-
-    def test_number_at_min(self):
-        text_filter = NumberRangeFilter(self.field_name_to_test, {
-            "min": self.number_to_test
-        })
-        assert len(text_filter.on_dicts(self.dicts)) == 1
+        filtered_dicts = text_filter.on_dicts(self.dicts)
+        assert len(filtered_dicts) == len(list(self.no_none_test_numbers))

--- a/queryfilter/tests/test_queryfilter.py
+++ b/queryfilter/tests/test_queryfilter.py
@@ -4,11 +4,9 @@ import pytest
 
 from ..queryfilter import QueryFilter
 from ..exceptions import (
-    FilterOnNoneValueError,
+    FilterOnNoneValue,
     FieldNotFound
 )
-from .. import textfilters
-from .. import numberfilters
 
 
 class TestTextFilter(object):
@@ -53,7 +51,7 @@ class TestTextFilter(object):
         })
         assert len(query_filter.on_dicts(dicts)) == 1
 
-    def est_False_drop_none_should_raise_FilterOnNoneValueError(self):
+    def est_False_drop_none_should_raise_FilterOnNoneValue(self):
         dicts = [
             {"age": None},
             {"age": 1},
@@ -68,5 +66,5 @@ class TestTextFilter(object):
                 "max": 1
             }
         })
-        with pytest.raises(FilterOnNoneValueError):
+        with pytest.raises(FilterOnNoneValue):
             query_filter.on_dicts(dicts)

--- a/queryfilter/tests/test_queryfilter.py
+++ b/queryfilter/tests/test_queryfilter.py
@@ -28,11 +28,13 @@ class TestTextFilter(object):
         query_filter = QueryFilter({
             "name": {
                 "type": "string",
+                "options": {"none_for_missing_field": False},
                 "condition": "contains",
                 "value": "example"
             }
         })
-        assert len(query_filter.on_dicts(dicts)) == 0
+        with pytest.raises(FieldNotFound):
+            query_filter.on_dicts(dicts)
 
     def test_True_drop_none_should_get_no_none_results(self):
         dicts = [
@@ -51,7 +53,7 @@ class TestTextFilter(object):
         })
         assert len(query_filter.on_dicts(dicts)) == 1
 
-    def test_False_drop_none_should_raise_FilterOnNoneValueError(self):
+    def est_False_drop_none_should_raise_FilterOnNoneValueError(self):
         dicts = [
             {"age": None},
             {"age": 1},

--- a/queryfilter/tests/test_queryfilter.py
+++ b/queryfilter/tests/test_queryfilter.py
@@ -1,23 +1,70 @@
 from __future__ import absolute_import
 
+import pytest
+
 from ..queryfilter import QueryFilter
+from ..exceptions import (
+    FilterOnNoneValueError,
+    FieldNotFound
+)
+from .. import textfilters
+from .. import numberfilters
 
 
 class TestTextFilter(object):
-    def setup(self):
-        self.field_name_to_test = "name"
-        self.text_to_test = "name_example"
-        self.dicts = [
-            {self.field_name_to_test: self.text_to_test}
-        ]
-
-    def test_query_filter(self):
+    def test_simple_query_filter(self):
+        dicts = [{"name": "name_example"}]
         query_filter = QueryFilter({
             "name": {
                 "type": "string",
                 "condition": "contains",
-                "value": self.field_name_to_test
+                "value": "example"
             }
         })
+        assert len(query_filter.on_dicts(dicts)) == 1
 
-        assert len(query_filter.on_dicts(self.dicts)) == 1
+    def test_simple_query_filter_with_field_not_found(self):
+        dicts = [{"address": "address_example"}]
+        query_filter = QueryFilter({
+            "name": {
+                "type": "string",
+                "condition": "contains",
+                "value": "example"
+            }
+        })
+        assert len(query_filter.on_dicts(dicts)) == 0
+
+    def test_True_drop_none_should_get_no_none_results(self):
+        dicts = [
+            {"age": None},
+            {"age": 1},
+            {"age": None},
+            {"age": 2},
+        ]
+        query_filter = QueryFilter({
+            "age": {
+                "type": "number",
+                "options": {"drop_none": True},
+                "min": 0,
+                "max": 1,
+            }
+        })
+        assert len(query_filter.on_dicts(dicts)) == 1
+
+    def test_False_drop_none_should_raise_FilterOnNoneValueError(self):
+        dicts = [
+            {"age": None},
+            {"age": 1},
+            {"age": None},
+            {"age": 2}
+        ]
+        query_filter = QueryFilter({
+            "age": {
+                "type": "number",
+                "options": {"drop_none": False},
+                "min": 0,
+                "max": 1
+            }
+        })
+        with pytest.raises(FilterOnNoneValueError):
+            query_filter.on_dicts(dicts)

--- a/queryfilter/textfilters.py
+++ b/queryfilter/textfilters.py
@@ -2,12 +2,12 @@ from __future__ import absolute_import
 from six import add_metaclass
 import abc
 
-from .base import FieldFilter
+from .base import FieldFilter, BaseDictFilter
 from .queryfilter import QueryFilter
 
 
 @add_metaclass(abc.ABCMeta)
-class TextMatchMixin(object):
+class TextMatchMixin(BaseDictFilter, object):
     @abc.abstractmethod
     def _is_value_matched(self, value): pass
 
@@ -15,10 +15,15 @@ class TextMatchMixin(object):
         return self.filter_args["value"]
 
     def on_dicts(self, dicts):
-        return [
-            d for d in dicts
-            if self._is_value_matched(d.get(self.field_name))
-        ]
+        kept_dicts = []
+        for d in dicts:
+            field_value = self.get(d, self.field_name)
+            if field_value is None:
+                self.false_with_drop_none_else_raise(self.field_name)
+                continue
+            if self._is_value_matched(field_value):
+                kept_dicts.append(d)
+        return kept_dicts
 
 
 @QueryFilter.register_type_condition('string', 'equals')

--- a/queryfilter/textfilters.py
+++ b/queryfilter/textfilters.py
@@ -2,12 +2,12 @@ from __future__ import absolute_import
 from six import add_metaclass
 import abc
 
-from .base import FieldFilter, BaseDictFilter
+from .base import FieldFilter, DictFilterMixin
 from .queryfilter import QueryFilter
 
 
 @add_metaclass(abc.ABCMeta)
-class TextMatchMixin(BaseDictFilter, object):
+class TextMatchMixin(DictFilterMixin):
     @abc.abstractmethod
     def _is_value_matched(self, value): pass
 
@@ -20,7 +20,7 @@ class TextMatchMixin(BaseDictFilter, object):
             field_value = self.get(d, self.field_name)
             if field_value is None:
                 self.false_with_drop_none_else_raise(self.field_name)
-                continue
+                continue  # skip on field value None
             if self._is_value_matched(field_value):
                 kept_dicts.append(d)
         return kept_dicts


### PR DESCRIPTION
# Purpose

Set default behaviors for None value with options
```python
query_filter = QueryFilter({
    "age": {
        "type": "number",
        "options": {"drop_none": True},  # default
        "min": 0,
        "max": 1,
    }
})
```

and non-existed field name

```python
query_filter = QueryFilter({
    "name": {
        "type": "string",
        "options": {"none_for_missing_field": True},  # default
        "condition": "contains",
        "value": "example"
    }
})
```

# Changes

- Add filter options to `QueryFilter` and add `BaseDictFilter` class.
- Add more tests in queryfilter.