### PR TITLE
ignore  empty string in birthday queryfilter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,17 @@ matrix:
     env: TOXENV=py36
   - python: 2.7
     env: TOXENV=py27
+
+addons:
+  apt:
+    sources:
+      - travis-ci/sqlite3
+    packages:
+      - sqlite3
+
 install:
 - pip install pip --upgrade
 - travis_retry pip install -e ".[dev]"
+
 script:
 - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,6 @@ matrix:
   - python: 2.7
     env: TOXENV=py27
 
-addons:
-  apt:
-    sources:
-      - travis-ci/sqlite3
-    packages:
-      - sqlite3
-
 install:
 - pip install pip --upgrade
 - travis_retry pip install -e ".[dev]"

--- a/queryfilter/birthdayfilters.py
+++ b/queryfilter/birthdayfilters.py
@@ -67,7 +67,7 @@ class BirthdayDateRangeFilter(DictFilterMixin, FieldFilter):
 
         def by_value_of_dict_field_in_range(dictobj):
             value = self.get(dictobj, self.field_name)
-            if value is None:
+            if value in (None, ''):
                 return self.false_with_drop_none_else_raise(self.field_name)
             month, day = self.split_month_day(value)
             return in_given_range(month, day)

--- a/queryfilter/tests/test_birthdayfilters.py
+++ b/queryfilter/tests/test_birthdayfilters.py
@@ -60,12 +60,6 @@ class TestBirthdayDateRangeFilter(object):
 
 
 class TestEmptyValue(object):
-    def setup(self):
-        self.field_name_to_test = "birth"
-        self.dates_to_test = ("12/31", "01/11", "02/29", "01/11")
-        self.dataset_to_test = [
-            {self.field_name_to_test: date} for date in self.dates_to_test
-        ]
 
     def test_empty_values(self):
 

--- a/queryfilter/tests/test_birthdayfilters.py
+++ b/queryfilter/tests/test_birthdayfilters.py
@@ -57,3 +57,30 @@ class TestBirthdayDateRangeFilter(object):
         results_after_filter = date_filter.on_dicts(self.dataset_to_test)
         assert len(results_after_filter) == 1
         assert results_after_filter[0]["birth"] == "02/29"
+
+
+class TestEmptyValue(object):
+    def setup(self):
+        self.field_name_to_test = "birth"
+        self.dates_to_test = ("12/31", "01/11", "02/29", "01/11")
+        self.dataset_to_test = [
+            {self.field_name_to_test: date} for date in self.dates_to_test
+        ]
+
+    def test_empty_values(self):
+
+        birth = 'birth'
+
+        date_filter = BirthdayDateRangeFilter(birth, {
+            "start": '01/11',
+            "end": '04/01',
+        })
+
+        data = [
+            {birth: ''},
+            {birth: None},
+            {birth: u''},
+        ]
+
+        results_after_filter = date_filter.on_dicts(data)
+        assert len(results_after_filter) == 0

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ required_dev = [
 
 setup(
     name="queryfilter",
-    version="0.4.6",
+    version="0.4.7",
     description=("Allow same query interface to be shared between Django ORM,"
                  "SQLAlchemy, and GraphQL backend."),
     long_description=open(os.path.join(source_root, "README.rst")).read(),

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ required_dev = [
     "flake8",
     "pytest-flake8",
     "tox",
-    "django<2.2",
+    "django",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ required_dev = [
     "flake8",
     "pytest-flake8",
     "tox",
-    "django",
+    "django<2.2",
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,6 @@ deps =
     pytest-cov
     pytest-flake8
     pytest-django
-    django
+    django < 2.2
 setenv =
     COVERAGE_FILE=.coverage.{envname}


### PR DESCRIPTION
# Purpose

https://sentry.io/organizations/ichefpos/issues/979486705/?project=205914&referrer=slack

apply queryfilter on empty value will cause an error in birthday filter.


## Changes
 * queryfilter will skip more kind of empty value
 * use Django version <2.2 due to Django 2.2 use too latest SQLite that Travis does not support currently