### PR TITLE
Support "," in textfilters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ matrix:
   include:
   - python: 3.6
     env: TOXENV=py36
-  - python: 2.7
-    env: TOXENV=py27
 
 install:
 - pip install pip --upgrade

--- a/queryfilter/tests/test_nested_filter.py
+++ b/queryfilter/tests/test_nested_filter.py
@@ -6,7 +6,7 @@ from ..exceptions import (
     FieldNotFound
 )
 from ..textfilters import (
-    TextFullyMatchedFilter
+    TextFullyMatchedFilter, TextStartsWithMatchedFilter
 )
 
 
@@ -37,6 +37,12 @@ class TestNestedFiler(object):
 
     def test_none_as_value_should_work_as_well(self):
         text_filter = TextFullyMatchedFilter(self.field_name_to_test, {
+            "value": None
+        })
+        assert len(text_filter.on_dicts(self.dicts)) == 0
+
+    def test_none_as_value_should_work_as_well_2(self):
+        text_filter = TextStartsWithMatchedFilter(self.field_name_to_test, {
             "value": None
         })
         assert len(text_filter.on_dicts(self.dicts)) == 0

--- a/queryfilter/tests/test_textfilters.py
+++ b/queryfilter/tests/test_textfilters.py
@@ -33,6 +33,14 @@ class TestTextFullyMatchedFilter(TextFilterTestBase):
 
         self.assert_filtered_data_length(text_filter, 1)
 
+    def test_text_fully_match_list(self):
+
+        text_filter = TextFullyMatchedFilter(self.field_name_to_test, {
+            "value": "not_existed," + self.text_to_test + ",not_existed2"
+        })
+
+        self.assert_filtered_data_length(text_filter, 1)
+
     def test_text_does_not_fully_match_should_fail(self):
 
         text_not_match = "not_name_example"
@@ -47,6 +55,12 @@ class TestTextPartialMatchedFilter(TextFilterTestBase):
     def test_text_partial_match(self):
         text_filter = TextPartialMatchedFilter(self.field_name_to_test, {
             "value": self.text_to_test[:1]
+        })
+        self.assert_filtered_data_length(text_filter, 1)
+
+    def test_text_partial_match_list(self):
+        text_filter = TextPartialMatchedFilter(self.field_name_to_test, {
+            "value": ("not_existed," + self.text_to_test[:1] + ",not_existed2")
         })
         self.assert_filtered_data_length(text_filter, 1)
 
@@ -65,6 +79,14 @@ class TestTextStartsWithMatchedFilter(TextFilterTestBase):
 
         text_filter = TextStartsWithMatchedFilter(self.field_name_to_test, {
             "value": self.text_to_test[:1]
+        })
+
+        self.assert_filtered_data_length(text_filter, 1)
+
+    def test_text_partial_match_list(self):
+
+        text_filter = TextStartsWithMatchedFilter(self.field_name_to_test, {
+            "value": "not_existed," + self.text_to_test[:1] + ",not_existed2"
         })
 
         self.assert_filtered_data_length(text_filter, 1)
@@ -91,10 +113,16 @@ class TestTextEndsWithMatchedFilter(TextFilterTestBase):
         })
         self.assert_filtered_data_length(text_filter, 1)
 
+    def test_text_partial_match_list(self):
+        text_filter = TextEndsWithMatchedFilter(self.field_name_to_test, {
+            "value": self.text_to_test[-1:]
+        })
+        self.assert_filtered_data_length(text_filter, 1)
+
     def test_text_does_not_partial_match_should_fail(self):
         text_not_match = "not"
         text_filter = TextEndsWithMatchedFilter(self.field_name_to_test, {
-            "value": text_not_match
+            "value": "not_existed," + text_not_match + ",not_existed2"
         })
         self.assert_filtered_data_length(text_filter, 0)
 

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,6 @@ setup(
         "Development Status :: 2 - Pre-Alpha",
         "Topic :: Database :: Front-Ends",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
     ],

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ required_dev = [
 
 setup(
     name="queryfilter",
-    version="0.5.0",
+    version="0.6.0",
     description=("Allow same query interface to be shared between Django ORM,"
                  "SQLAlchemy, and GraphQL backend."),
     long_description=open(os.path.join(source_root, "README.rst")).read(),

--- a/tox.ini
+++ b/tox.ini
@@ -5,12 +5,11 @@
 
 [tox]
 # NOTE: Remember to update tox-args of make test in docker-compose-test.xml
-envlist = py27,py36
+envlist = py36
 
 [testenv]
 basepython =
     py36: python3.6
-    py27: python2.7
 commands = pytest --flake8 --junitxml=ci/junit-{envname}.xml
 deps =
     pytest


### PR DESCRIPTION
# Purpose

Support "," in textfilters

# Changes

- Textfilter now takes "," as splitter, and accept multiple keywords.
